### PR TITLE
Actually install dependencies in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,11 @@ jobs:
             # fallback to using the latest cache if no exact match is found
             - v1-dependencies-
 
+      # Update dependencies
+      - run:
+          name: Update dependencies
+          command: npm install
+
       - save_cache:
           paths:
             - node_modules

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-microfe",
-  "version": "1.0.3",
+  "version": "1.0.6-alpha.0",
   "description": "",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Circle CI can't run tests if dependencies are not installed (and the previous cache has long since disappeared). This fixes things so we actually use and update the cache. (I'm actually in favor of switching to `npm ci` to use the dependency versions in package-lock.json, but not doing that now.)